### PR TITLE
Add server launcher main class

### DIFF
--- a/src/main/java/org/quiltmc/Meta.java
+++ b/src/main/java/org/quiltmc/Meta.java
@@ -319,7 +319,10 @@ public class Meta implements RequestHandler<APIGatewayProxyRequestEvent, APIGate
                     if (launcherMeta.get("mainClass").isJsonObject()) {
                         object.addProperty("mainClass", launcherMeta.get("mainClass").getAsJsonObject().get(side.side).getAsString());
                     }
-
+                    if (side == Side.SERVER) {
+                        // Add the server launch main class
+                        object.addProperty("launcherMainClass", launcherMeta.get("mainClass").getAsJsonObject().get("launcherMainClass").getAsString());
+                    }
                     object.add("arguments", arguments);
                     object.add("libraries", libraries);
 


### PR DESCRIPTION
This makes the installer pretty much entirely resistant to package and class name refactors in Loader, and avoids us having to search through all our libraries for Quilt Loader, open the jar, read the installer json, etc just for one value.